### PR TITLE
Point out cf service-key changes

### DIFF
--- a/v8.html.md.erb
+++ b/v8.html.md.erb
@@ -68,6 +68,7 @@ Some of these changes are:
 
 * Style changes, including changes in the order or wording of the output.
 * cf CLI v8 uses CAPI V3 to make requests related to services. CAPI V3 creates asynchronous jobs. If you want to continue to create jobs synchronously, use the new `--wait` flag.
+* JSON response changes such as additional elements or nesting.
 
 
 ### <a id="table"></a> Table of Differences
@@ -180,6 +181,7 @@ The table below summarizes how commands differ between cf CLI v7 and cf CLI v8.
     <td>
       <ul>
         <li><strong>[Update]:</strong> Displays information about <code>last operation</code> and <code>message</code> as new columns.</li>
+        <li><strong>[Response]:</strong> All JSON response elements from v7 are now wrapped into an additional element named <code>credentials</code>.</li>
       </ul>
     </td>
   </tr>


### PR DESCRIPTION
The output of the command `cf service-key` changed in a breaking way. All JSON elements that were on the JSON root level with v6 and v7 are now with v8 underneath a single root element called `credentials`. This breaks automated parsing of the JSON and is worth mentioning.